### PR TITLE
Assume shared album folder and auto-detect installed albums

### DIFF
--- a/app/core/caching_worker.py
+++ b/app/core/caching_worker.py
@@ -1,48 +1,37 @@
 from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
 from app.core.image_cache_manager import cache_image_if_needed
 
+
 class CachingWorker(QObject):
     progress_updated = pyqtSignal(int)
     finished = pyqtSignal()
 
-    def __init__(self, albums, all_or_some, selected_albums, shared_or_separate, shared_directory, separate_directories):
+    def __init__(self, albums, shared_directory):
         super().__init__()
-        self.albums = albums
-        self.all_or_some = all_or_some
-        self.selected_albums = selected_albums
-        self.shared_or_separate = shared_or_separate
+        self.albums = [a for a in albums if a.get('type') in ["Live", "Compilation", "Studio"]]
         self.shared_directory = shared_directory
-        self.separate_directories = separate_directories
-
-        # Filter albums
-        if self.all_or_some == "all":
-            self.display_albums = self.albums
-        else:
-            self.display_albums = [a for a in self.albums if a['title'] in self.selected_albums]
-
-        # Only consider albums with recognized type
-        self.display_albums = [a for a in self.display_albums if a.get('type') in ["Live", "Compilation", "Studio"]]
-
-        self.total = len(self.display_albums)
-        # Pre-cache the common size used by all_albums_view
+        self.total = len(self.albums)
         self.size = (175, 175)
 
     @pyqtSlot()
     def run(self):
-        for i, album in enumerate(self.display_albums, start=1):
-            # Pre-cache the 175x175 image
+        if self.total == 0:
+            self.progress_updated.emit(100)
+            self.finished.emit()
+            return
+
+        for i, album in enumerate(self.albums, start=1):
             cache_image_if_needed(
                 album,
-                self.shared_or_separate,
                 self.shared_directory,
-                self.separate_directories,
                 width=self.size[0],
                 height=self.size[1],
                 format="JPG",
-                quality=95
+                quality=95,
             )
 
             progress = int((i / self.total) * 100)
             self.progress_updated.emit(progress)
 
         self.finished.emit()
+

--- a/app/core/file_verifier.py
+++ b/app/core/file_verifier.py
@@ -1,127 +1,27 @@
 import os
 
+
 class FileVerifier:
     def __init__(self, albums_manager):
         self.albums_manager = albums_manager
 
-    def verify_all_shared(self, shared_directory):
-        """
-        Verify that all albums listed in albums.json are found under the shared directory.
-        Each album has a 'directory' name and each track has a 'track_file'.
-        """
-        missing = []
-        all_albums = self.albums_manager.get_albums()
-        for album in all_albums:
-            album_dir = os.path.join(shared_directory, album['directory'])
-            if not os.path.isdir(album_dir):
-                missing.append(f"Missing album directory: {album_dir}")
-                continue
+    def find_existing_albums(self, shared_directory):
+        """Return list of albums found in the shared directory."""
+        present = []
+        for album in self.albums_manager.get_albums():
+            album_dir = os.path.join(shared_directory, album.get("directory", ""))
+            if os.path.isdir(album_dir):
+                present.append(album)
+        return present
 
-            for track in album.get('tracks', []):
-                track_path = os.path.join(album_dir, track['track_file'])
+    def verify_existing_shared(self, shared_directory):
+        """Verify track files for albums present in the shared directory."""
+        missing = []
+        for album in self.find_existing_albums(shared_directory):
+            album_dir = os.path.join(shared_directory, album.get("directory", ""))
+            for track in album.get("tracks", []):
+                track_path = os.path.join(album_dir, track.get("track_file", ""))
                 if not os.path.isfile(track_path):
                     missing.append(f"Missing track file: {track_path}")
-
         return missing
 
-    def verify_all_separate(self, separate_directories):
-        """
-        Verify that for all albums, the directories and track files exist.
-        separate_directories is a dict {album_title: album_directory_path}
-        """
-        missing = []
-        all_albums = self.albums_manager.get_albums()
-        for album in all_albums:
-            album_title = album['title']
-            if album_title not in separate_directories:
-                missing.append(f"No directory specified for album: {album_title}")
-                continue
-
-            album_dir = separate_directories[album_title]
-            if not os.path.isdir(album_dir):
-                missing.append(f"Missing album directory: {album_dir}")
-                continue
-
-            for track in album.get('tracks', []):
-                track_path = os.path.join(album_dir, track['track_file'])
-                if not os.path.isfile(track_path):
-                    missing.append(f"Missing track file: {track_path}")
-
-        return missing
-
-    def verify_some_shared(self, selected_albums, shared_directory):
-        """
-        Verify that only the selected albums are checked, each under the shared directory.
-        """
-        missing = []
-        # Create a lookup of albums by title
-        albums_by_title = {a['title']: a for a in self.albums_manager.get_albums()}
-        for album_title in selected_albums:
-            if album_title not in albums_by_title:
-                missing.append(f"Album not found in albums.json: {album_title}")
-                continue
-
-            album = albums_by_title[album_title]
-            album_dir = os.path.join(shared_directory, album['directory'])
-            if not os.path.isdir(album_dir):
-                missing.append(f"Missing album directory: {album_dir}")
-                continue
-
-            for track in album.get('tracks', []):
-                track_path = os.path.join(album_dir, track['track_file'])
-                if not os.path.isfile(track_path):
-                    missing.append(f"Missing track file: {track_path}")
-
-        return missing
-
-    def verify_some_separate(self, selected_albums, separate_directories):
-        """
-        Verify that only the selected albums are checked, each in its specified directory.
-        """
-        missing = []
-        albums_by_title = {a['title']: a for a in self.albums_manager.get_albums()}
-        for album_title in selected_albums:
-            if album_title not in albums_by_title:
-                missing.append(f"Album not found in albums.json: {album_title}")
-                continue
-
-            album = albums_by_title[album_title]
-
-            if album_title not in separate_directories:
-                missing.append(f"No directory specified for album: {album_title}")
-                continue
-
-            album_dir = separate_directories[album_title]
-            if not os.path.isdir(album_dir):
-                missing.append(f"Missing album directory: {album_dir}")
-                continue
-
-            for track in album.get('tracks', []):
-                track_path = os.path.join(album_dir, track['track_file'])
-                if not os.path.isfile(track_path):
-                    missing.append(f"Missing track file: {track_path}")
-
-        return missing
-
-    def verify(self, all_or_some, shared_or_separate, selected_albums=None, shared_directory=None, separate_directories=None):
-        """
-        High-level verification method that decides which verification method to call
-        based on the scenario.
-        
-        Returns:
-            missing (list): A list of missing directories or files (strings).
-            If empty, it means everything was found.
-        """
-        selected_albums = selected_albums or []
-        separate_directories = separate_directories or {}
-
-        if all_or_some == "all" and shared_or_separate == "shared":
-            return self.verify_all_shared(shared_directory)
-        elif all_or_some == "all" and shared_or_separate == "separate":
-            return self.verify_all_separate(separate_directories)
-        elif all_or_some == "some" and shared_or_separate == "shared":
-            return self.verify_some_shared(selected_albums, shared_directory)
-        elif all_or_some == "some" and shared_or_separate == "separate":
-            return self.verify_some_separate(selected_albums, separate_directories)
-        else:
-            return ["Invalid scenario provided."]

--- a/app/core/flow_manager.py
+++ b/app/core/flow_manager.py
@@ -5,81 +5,10 @@ class FlowManager:
 
     def run_flow(self, main_window):
         c = main_window.setup_flow_controller
-
-        all_or_some = self.settings_manager.settings.get("all_or_some", None)
-        shared_or_separate = self.settings_manager.settings.get("shared_or_separate", None)
-        selected_albums = self.settings_manager.settings.get("selected_albums", [])
         shared_directory = self.settings_manager.settings.get("shared_directory", None)
-        separate_directories = self.settings_manager.settings.get("separate_directories", {})
-
-        albums_manager = self.albums_manager
-        all_album_titles = [a["title"] for a in albums_manager.get_albums()]
-
-        def have_all_separate_dirs():
-            if not separate_directories:
-                return False
-            for title in all_album_titles:
-                if title not in separate_directories or not separate_directories[title]:
-                    return False
-            return True
-
-        def have_some_separate_dirs():
-            if not separate_directories or not selected_albums:
-                return False
-            for title in selected_albums:
-                if title not in separate_directories or not separate_directories[title]:
-                    return False
-            return True
-
-        if all_or_some and shared_or_separate:
-            # Assign states to the setup_flow_controller
-            c.all_or_some = all_or_some
-            c.shared_or_separate = shared_or_separate
-            c.selected_albums = selected_albums or []
-
-            # "All & Shared"
-            if all_or_some == "all" and shared_or_separate == "shared":
-                if shared_directory:
-                    # Everything is known, skip showing directory step and verify immediately
-                    c.current_shared_directory = shared_directory
-                    c.auto_verify_and_finish()
-                else:
-                    # Need directory
-                    main_window.show_shared_directory_step()
-
-            # "All & Separate"
-            elif all_or_some == "all" and shared_or_separate == "separate":
-                if have_all_separate_dirs():
-                    # Directories known, verify immediately
-                    c.current_separate_directories = separate_directories
-                    c.auto_verify_and_finish()
-                else:
-                    main_window.show_separate_directories_step(albums=all_album_titles, prefill=separate_directories)
-
-            # "Some & Shared"
-            elif all_or_some == "some" and shared_or_separate == "shared":
-                if selected_albums and shared_directory:
-                    # Everything known, verify immediately
-                    c.current_shared_directory = shared_directory
-                    c.auto_verify_and_finish()
-                else:
-                    if not selected_albums:
-                        main_window.show_select_albums_step()
-                    else:
-                        main_window.show_shared_directory_step(prefill=shared_directory)
-
-            # "Some & Separate"
-            elif all_or_some == "some" and shared_or_separate == "separate":
-                if selected_albums and have_some_separate_dirs():
-                    # Everything known, verify immediately
-                    c.current_separate_directories = separate_directories
-                    c.auto_verify_and_finish()
-                else:
-                    if not selected_albums:
-                        main_window.show_select_albums_step()
-                    else:
-                        main_window.show_separate_directories_step(albums=selected_albums, prefill=separate_directories)
-
+        if shared_directory:
+            c.current_directory = shared_directory
+            c.auto_verify_and_finish()
         else:
-            # No initial answers remembered, show initial questions
-            main_window.show_initial_questions()
+            main_window.show_directory_step()
+

--- a/app/core/image_cache_manager.py
+++ b/app/core/image_cache_manager.py
@@ -24,7 +24,7 @@ def get_cached_image_path(album_title: str, width: int, height: int) -> str:
     cache_filename = f"{slug}_{width}x{height}.jpg"  # or .png
     return os.path.join(get_cache_dir(), cache_filename)
 
-def cache_image_if_needed(album, shared_or_separate, shared_directory, separate_directories, width, height, format="JPG", quality=95):
+def cache_image_if_needed(album, shared_directory, width, height, format="JPG", quality=95):
     """
     Ensure there's a cached image for the given album at the specified size.
     If not cached, it will create and save it.
@@ -38,7 +38,7 @@ def cache_image_if_needed(album, shared_or_separate, shared_directory, separate_
         return cache_path
 
     # Get original path
-    original_path = get_original_art_path(album, shared_or_separate, shared_directory, separate_directories)
+    original_path = get_original_art_path(album, shared_directory)
     if not os.path.isfile(original_path):
         return ""
 

--- a/app/core/path_utils.py
+++ b/app/core/path_utils.py
@@ -1,13 +1,9 @@
 import os
 
-def get_original_art_path(album, shared_or_separate, shared_directory, separate_directories):
-    album_art_file = album.get('album_art', 'cover.jpg')
-    if shared_or_separate == "shared":
-        if shared_directory and album.get('directory'):
-            return os.path.join(shared_directory, album['directory'], album_art_file)
-    else:
-        # separate
-        album_title = album['title']
-        if album_title in separate_directories:
-            return os.path.join(separate_directories[album_title], album_art_file)
+
+def get_original_art_path(album, shared_directory):
+    album_art_file = album.get("album_art", "cover.jpg")
+    if shared_directory and album.get("directory"):
+        return os.path.join(shared_directory, album["directory"], album_art_file)
     return ""
+

--- a/app/core/setup_flow_controller.py
+++ b/app/core/setup_flow_controller.py
@@ -5,6 +5,7 @@ from app.core.caching_worker import CachingWorker
 from app.ui.album_views.all_albums_view import AllAlbumsView
 from app.ui.setup.welcome_dialog import WelcomeDialog
 
+
 class SetupFlowController:
     def __init__(self, main_window):
         self.main_window = main_window
@@ -12,11 +13,8 @@ class SetupFlowController:
         self.albums_manager = self.main_window.albums_manager
         self.verifier = self.main_window.verifier
 
-        self.all_or_some = None
-        self.shared_or_separate = None
-        self.selected_albums = []
-        self.current_shared_directory = None
-        self.current_separate_directories = {}
+        self.current_directory = None
+        self.available_albums = []
 
     def show_welcome_dialog_if_needed(self):
         if self.settings_manager.should_show_welcome():
@@ -27,136 +25,50 @@ class SetupFlowController:
                 self.settings_manager.set_show_welcome(False)
                 self.settings_manager.save()
 
-    def handle_initial_questions_continue(self, all_or_some, shared_or_separate, remember):
-        if remember:
-            self.settings_manager.set_value("all_or_some", all_or_some)
-            self.settings_manager.set_value("shared_or_separate", shared_or_separate)
-            self.settings_manager.save()
-
-        self.all_or_some = all_or_some
-        self.shared_or_separate = shared_or_separate
-
-        # Move to next step based on choices
-        if self.all_or_some == "all":
-            # For all albums
-            if self.shared_or_separate == "shared":
-                self.main_window.show_shared_directory_step()
-            else:
-                # separate
-                all_album_titles = [a["title"] for a in self.albums_manager.get_albums()]
-                self.main_window.show_separate_directories_step(albums=all_album_titles)
-        else:
-            # some
-            self.main_window.show_select_albums_step()
-
-    def handle_start_over(self):
-        """
-        Clears remembered setup values, resets local state,
-        and returns the user to the initial questions step.
-        """
-        # Clear settings in the SettingsManager
-        self.settings_manager.set_value("all_or_some", None)
-        self.settings_manager.set_value("shared_or_separate", None)
-        self.settings_manager.set_value("selected_albums", [])
-        self.settings_manager.set_value("shared_directory", None)
-        self.settings_manager.set_value("separate_directories", {})
-        self.settings_manager.save()
-
-        # Clear controller state
-        self.all_or_some = None
-        self.shared_or_separate = None
-        self.selected_albums = []
-        self.current_shared_directory = None
-        self.current_separate_directories = {}
-
-        # Show initial questions screen
-        self.main_window.show_initial_questions()
-
-    def handle_select_albums_continue(self, selected_albums, remember):
-        self.selected_albums = selected_albums
-        if remember:
-            self.settings_manager.set_value("selected_albums", self.selected_albums)
-            self.settings_manager.save()
-
-        if self.shared_or_separate == "shared":
-            self.main_window.show_shared_directory_step()
-        else:
-            # separate
-            self.main_window.show_separate_directories_step(albums=self.selected_albums)
-
-    def handle_shared_directory_continue(self, directory, remember):
-        self.current_shared_directory = directory
+    def handle_directory_continue(self, directory, remember):
+        self.current_directory = directory
         if remember:
             self.settings_manager.set_value("shared_directory", directory)
             self.settings_manager.save()
 
-        # Verify files now
-        missing = self.verifier.verify(
-            all_or_some=self.all_or_some,
-            shared_or_separate=self.shared_or_separate,
-            selected_albums=self.selected_albums,
-            shared_directory=directory
-        )
-
+        missing = self.verifier.verify_existing_shared(directory)
         if missing:
             self.show_missing_files_dialog(missing)
         else:
             self.finish_setup()
 
-    def handle_separate_directories_continue(self, directories, remember):
-        self.current_separate_directories = directories
-        if remember:
-            self.settings_manager.set_value("separate_directories", directories)
-            self.settings_manager.save()
-
-        # Verify files now
-        missing = self.verifier.verify(
-            all_or_some=self.all_or_some,
-            shared_or_separate=self.shared_or_separate,
-            selected_albums=self.selected_albums,
-            separate_directories=directories
-        )
-
-        if missing:
-            self.show_missing_files_dialog(missing)
-        else:
-            self.finish_setup()
+    def handle_start_over(self):
+        self.settings_manager.set_value("shared_directory", None)
+        self.settings_manager.save()
+        self.current_directory = None
+        self.available_albums = []
+        self.main_window.show_directory_step()
 
     def auto_verify_and_finish(self):
         directory = self.settings_manager.settings.get("shared_directory", None)
-        directories = self.settings_manager.settings.get("separate_directories", {})
-        selected_albums = self.settings_manager.settings.get("selected_albums", [])
-
-        missing = self.verifier.verify(
-            all_or_some=self.all_or_some,
-            shared_or_separate=self.shared_or_separate,
-            selected_albums=selected_albums,
-            shared_directory=directory,
-            separate_directories=directories
-        )
-
-        if missing:
-            self.show_missing_files_dialog(missing)
+        if directory:
+            missing = self.verifier.verify_existing_shared(directory)
+            if missing:
+                self.show_missing_files_dialog(missing)
+            else:
+                self.current_directory = directory
+                self.finish_setup()
         else:
-            self.finish_setup()
+            self.main_window.show_directory_step()
 
     def finish_setup(self):
         self.main_window.stack.setCurrentWidget(self.main_window.loading_screen)
 
-        all_albums = self.albums_manager.get_albums()
-        selected_albums = self.selected_albums or self.settings_manager.settings.get("selected_albums", [])
-
-        shared_directory = self.current_shared_directory or self.settings_manager.settings.get("shared_directory", None)
-        separate_directories = self.current_separate_directories or self.settings_manager.settings.get("separate_directories", {})
+        import os
+        self.available_albums = [
+            a for a in self.albums_manager.get_albums()
+            if os.path.isdir(os.path.join(self.current_directory, a.get("directory", "")))
+        ]
 
         self.thread = QThread()
         self.worker = CachingWorker(
-            albums=all_albums,
-            all_or_some=self.all_or_some,
-            selected_albums=selected_albums,
-            shared_or_separate=self.shared_or_separate,
-            shared_directory=shared_directory,
-            separate_directories=separate_directories
+            albums=self.available_albums,
+            shared_directory=self.current_directory,
         )
         self.worker.moveToThread(self.thread)
 
@@ -170,22 +82,16 @@ class SetupFlowController:
         self.thread.start()
 
     def on_caching_finished(self):
-        # After caching, show all albums view
-        shared_directory = self.current_shared_directory or self.settings_manager.settings.get("shared_directory", None)
-        separate_directories = self.current_separate_directories or self.settings_manager.settings.get("separate_directories", {})
-
         self.main_window.all_albums_view = AllAlbumsView(
             albums_manager=self.albums_manager,
             settings_manager=self.settings_manager,
             flow_controller=self,
-            all_or_some=self.all_or_some,
-            selected_albums=self.selected_albums,
-            shared_or_separate=self.shared_or_separate,
-            shared_directory=self.current_shared_directory,
-            separate_directories=self.current_separate_directories
+            albums=self.available_albums,
+            shared_directory=self.current_directory,
         )
-        # Connect album_clicked to navigation
-        self.main_window.all_albums_view.album_clicked.connect(self.main_window.navigation_controller.show_single_album_view)
+        self.main_window.all_albums_view.album_clicked.connect(
+            self.main_window.navigation_controller.show_single_album_view
+        )
         self.main_window.stack.addWidget(self.main_window.all_albums_view)
         self.main_window.stack.setCurrentWidget(self.main_window.all_albums_view)
 
@@ -199,4 +105,4 @@ class SetupFlowController:
         msg.setInformativeText("\n".join(missing))
         msg.setStandardButtons(QMessageBox.StandardButton.Ok)
         msg.exec()
-        # User can go back and fix directories themselves
+

--- a/app/ui/album_views/all_albums_view.py
+++ b/app/ui/album_views/all_albums_view.py
@@ -53,17 +53,13 @@ class AlbumItemWidget(QWidget):
 class AllAlbumsView(QWidget):
     album_clicked = pyqtSignal(str)
 
-    def __init__(self, albums_manager, settings_manager, flow_controller, all_or_some, selected_albums, shared_or_separate, shared_directory=None, separate_directories=None):
+    def __init__(self, albums_manager, settings_manager, flow_controller, albums, shared_directory):
         super().__init__()
         self.albums_manager = albums_manager
         self.settings_manager = settings_manager
         self.flow_controller = flow_controller
-        self.all_or_some = all_or_some
-        self.selected_albums = selected_albums
-        self.shared_or_separate = shared_or_separate
-
-        self.shared_directory = shared_directory if shared_directory is not None else self.settings_manager.settings.get("shared_directory", None)
-        self.separate_directories = separate_directories if separate_directories else self.settings_manager.settings.get("separate_directories", {})
+        self.albums = albums
+        self.shared_directory = shared_directory
 
         self.main_layout = QVBoxLayout()
         self.main_layout.setContentsMargins(20, 20, 20, 20)
@@ -109,19 +105,13 @@ class AllAlbumsView(QWidget):
         self.container_layout.setContentsMargins(0, 0, 0, 0)
         self.container_layout.setSpacing(30)
 
-        all_albums = self.albums_manager.get_albums()
-        if self.all_or_some == "all":
-            display_albums = all_albums
-        else:
-            display_albums = [a for a in all_albums if a['title'] in self.selected_albums]
-
         categories = {
             "Live": [],
             "Compilation": [],
             "Studio": []
         }
 
-        for album in display_albums:
+        for album in self.albums:
             album_type = album.get('type', '')
             if album_type in categories:
                 categories[album_type].append(album)

--- a/app/ui/album_views/single_album_view.py
+++ b/app/ui/album_views/single_album_view.py
@@ -4,17 +4,16 @@ from PyQt6.QtGui import QPixmap
 from PyQt6.QtWidgets import (QHBoxLayout, QLabel, QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget)
 from app.core.image_cache_manager import cache_image_if_needed
 
+
 class SingleAlbumView(QWidget):
     back_clicked = pyqtSignal()
     track_clicked = pyqtSignal(int)  # emit the track index (1-based)
 
-    def __init__(self, albums_manager, album_title, shared_or_separate, shared_directory, separate_directories):
+    def __init__(self, albums_manager, album_title, shared_directory):
         super().__init__()
         self.albums_manager = albums_manager
         self.album_title = album_title
-        self.shared_or_separate = shared_or_separate
         self.shared_directory = shared_directory
-        self.separate_directories = separate_directories
         self.last_track_list_scroll_pos = 0
 
         album = self.get_album_data(album_title)
@@ -32,13 +31,11 @@ class SingleAlbumView(QWidget):
         # Attempt to cache and load a 500x500 image
         large_art_path = cache_image_if_needed(
             album,
-            self.shared_or_separate,
             self.shared_directory,
-            self.separate_directories,
             width=500,
             height=500,
             format="JPG",
-            quality=95
+            quality=95,
         )
 
         art_label = QLabel()

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -6,10 +6,7 @@ from app.core.file_verifier import FileVerifier
 from app.core.setup_flow_controller import SetupFlowController
 from app.core.navigation_controller import NavigationController
 
-from app.ui.setup.initial_questions import InitialQuestionsStep
-from app.ui.setup.select_albums import SelectAlbumsStep
 from app.ui.setup.shared_directory import SharedDirectoryStep
-from app.ui.setup.separate_directories import SeparateDirectoriesStep
 from app.ui.setup.loading_screen import LoadingScreen
 
 class MainWindow(QMainWindow):
@@ -33,35 +30,18 @@ class MainWindow(QMainWindow):
         self.navigation_controller = NavigationController(self)
 
         # UI Steps
-        self.initial_step = InitialQuestionsStep(parent=self)
-        self.select_albums_step = SelectAlbumsStep(
-            albums_manager=self.albums_manager,
-            flow_controller=self.setup_flow_controller,
-            parent=self
-        )
         self.shared_directory_step = SharedDirectoryStep(
-            flow_controller=self.setup_flow_controller, 
-            parent=self
-        )
-        self.separate_directories_step = SeparateDirectoriesStep(
-            albums_manager=self.albums_manager,
             flow_controller=self.setup_flow_controller,
             parent=self
         )
         self.loading_screen = LoadingScreen(parent=self)
 
         # Add steps to the stack
-        self.stack.addWidget(self.initial_step)
-        self.stack.addWidget(self.select_albums_step)
         self.stack.addWidget(self.shared_directory_step)
-        self.stack.addWidget(self.separate_directories_step)
         self.stack.addWidget(self.loading_screen)
 
         # Connect signals from steps to SetupFlowController methods
-        self.initial_step.continue_clicked.connect(self.setup_flow_controller.handle_initial_questions_continue)
-        self.select_albums_step.continue_clicked.connect(self.setup_flow_controller.handle_select_albums_continue)
-        self.shared_directory_step.continue_clicked.connect(self.setup_flow_controller.handle_shared_directory_continue)
-        self.separate_directories_step.continue_clicked.connect(self.setup_flow_controller.handle_separate_directories_continue)
+        self.shared_directory_step.continue_clicked.connect(self.setup_flow_controller.handle_directory_continue)
 
         # Variables used by NavigationController
         self.last_all_albums_scroll_pos = 0
@@ -86,24 +66,12 @@ class MainWindow(QMainWindow):
         if window_settings.get("maximized", False):
             self.showMaximized()
 
-    def show_initial_questions(self):
-        self.stack.setCurrentWidget(self.initial_step)
-
-    def show_select_albums_step(self):
-        self.stack.setCurrentWidget(self.select_albums_step)
-
-    def show_shared_directory_step(self, prefill=None):
+    def show_directory_step(self, prefill=None):
         if prefill:
             self.shared_directory_step.dir_edit.setText(prefill)
+        else:
+            self.shared_directory_step.dir_edit.clear()
         self.stack.setCurrentWidget(self.shared_directory_step)
-
-    def show_separate_directories_step(self, albums, prefill=None):
-        self.separate_directories_step.set_albums(albums)
-        if prefill:
-            for title, path in prefill.items():
-                if title in self.separate_directories_step.album_lineedits:
-                    self.separate_directories_step.album_lineedits[title].setText(path)
-        self.stack.setCurrentWidget(self.separate_directories_step)
 
     def closeEvent(self, event: QCloseEvent):
         if self.isMaximized():

--- a/app/ui/transitions/transitions_view.py
+++ b/app/ui/transitions/transitions_view.py
@@ -18,16 +18,13 @@ class TransitionsView(QWidget):
     done_clicked = pyqtSignal()
 
     def __init__(self, albums_manager, settings_manager, current_album_title,
-                 current_track_index, shared_or_separate, shared_directory,
-                 separate_directories):
+                 current_track_index, available_albums):
         super().__init__()
         self.albums_manager = albums_manager
         self.settings_manager = settings_manager
         self.current_album_title = current_album_title
         self.current_track_index = current_track_index
-        self.shared_or_separate = shared_or_separate
-        self.shared_directory = shared_directory
-        self.separate_directories = separate_directories
+        self.available_albums = available_albums
 
         self.timeline_entries = load_initial_timeline(self.albums_manager, self.current_album_title, self.current_track_index)
 
@@ -281,10 +278,7 @@ class TransitionsView(QWidget):
         Returns a list of album titles the user actually selected if in 'some' mode;
         or returns [] if the user chose 'all' (to indicate no filtering).
         """
-        if self.settings_manager.settings.get("all_or_some") == "all":
-            return []
-        else:
-            return self.settings_manager.settings.get("selected_albums", [])
+        return self.available_albums
 
     def update_timeline(self):
         segs = compute_segments_from_timeline(self.timeline_entries)


### PR DESCRIPTION
## Summary
- Simplify first-time setup to request a single shared folder and remember it if desired
- Scan specified folder to find available albums and cache art for those albums
- Update navigation and views to work with the detected album list

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6890cfd18450832fa1bd111ef2f96728