### PR TITLE
Refine timeline playback controls and caching

### DIFF
--- a/app/ui/common/loading_dialog.py
+++ b/app/ui/common/loading_dialog.py
@@ -19,6 +19,7 @@ class LoadingDialog(QDialog):
 
         self.progress = QProgressBar()
         self.progress.setRange(0, 0)  # Busy indicator
-        layout.addWidget(self.progress)
+        self.progress.setFixedWidth(200)
+        layout.addWidget(self.progress, alignment=Qt.AlignmentFlag.AlignCenter)
 
         self.setLayout(layout)


### PR DESCRIPTION
## Summary
- Place Process & Play button on the left and ensure existing audio playback closes before reprocessing
- Center the busy indicator in the Process & Play loading dialog
- Improve seek bar to jump accurately on click/hover and reuse cached mix when saving

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68925150ac84832f9b58aec0c831be0b