### PR TITLE
Stop stale playback and align loading indicator

### DIFF
--- a/app/ui/common/loading_dialog.py
+++ b/app/ui/common/loading_dialog.py
@@ -1,5 +1,11 @@
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QProgressBar
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QLabel,
+    QProgressBar,
+    QHBoxLayout,
+)
 
 
 class LoadingDialog(QDialog):
@@ -15,11 +21,20 @@ class LoadingDialog(QDialog):
 
         self.label = QLabel("Processing...\nPlease wait, this might take a minute or two.")
         self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(self.label)
+        self.label.setWordWrap(True)
+        self.label.setFixedWidth(200)
+        layout.addWidget(self.label, alignment=Qt.AlignmentFlag.AlignCenter)
 
         self.progress = QProgressBar()
         self.progress.setRange(0, 0)  # Busy indicator
         self.progress.setFixedWidth(200)
-        layout.addWidget(self.progress, alignment=Qt.AlignmentFlag.AlignCenter)
 
+        progress_row = QHBoxLayout()
+        progress_row.addStretch()
+        progress_row.addWidget(self.progress)
+        progress_row.addStretch()
+        layout.addLayout(progress_row)
+
+        layout.setSizeConstraint(QVBoxLayout.SizeConstraint.SetFixedSize)
         self.setLayout(layout)
+        self.adjustSize()

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -32,6 +32,8 @@ class MainWindow(QMainWindow):
         # Cached mix info for Process & Play feature
         self.cached_mix_path = None
         self.cached_timeline_entries = None
+        # Reference to any active audio player dialog
+        self.player_dialog = None
 
         # UI Steps
         self.shared_directory_step = SharedDirectoryStep(

--- a/app/ui/player/audio_player_dialog.py
+++ b/app/ui/player/audio_player_dialog.py
@@ -146,4 +146,7 @@ class AudioPlayerDialog(QDialog):
 
     def closeEvent(self, event):  # type: ignore[override]
         self.media_player.stop()
+        parent = self.parent()
+        if parent and hasattr(parent, "player_dialog"):
+            parent.player_dialog = None
         super().closeEvent(event)

--- a/app/ui/transitions/transitions_view.py
+++ b/app/ui/transitions/transitions_view.py
@@ -335,9 +335,11 @@ class TransitionsView(QWidget):
     # ------------------------------------------------------------------
     def on_process_play_clicked(self):
         """Generate the final mix to the cache directory and play it."""
-        if self.player_dialog is not None:
-            self.player_dialog.close()
-            self.player_dialog = None
+        main_window = self.window()
+        if main_window and getattr(main_window, "player_dialog", None):
+            main_window.player_dialog.close()
+            main_window.player_dialog = None
+        self.player_dialog = None
         # Prepare timeline entries with file paths
         timeline_copy = deepcopy(self.timeline_entries)
         shared_directory = self.settings_manager.settings.get("shared_directory")
@@ -377,5 +379,7 @@ class TransitionsView(QWidget):
             main_window.cached_timeline_entries = deepcopy(timeline_copy)
 
         self.player_dialog = AudioPlayerDialog(out_path, parent=main_window)
+        if main_window:
+            main_window.player_dialog = self.player_dialog
         self.player_dialog.show()
 


### PR DESCRIPTION
## Summary
- ensure new Process & Play sessions close any existing audio player
- center the loading bar and wrap long messaging in the processing dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892597ba5d0832fa8d65b642f4d2f6e