### PR TITLE
Show albums data version and allow audio player resizing

### DIFF
--- a/app/core/albums_manager.py
+++ b/app/core/albums_manager.py
@@ -12,38 +12,62 @@ def get_user_albums_path():
 
 class AlbumsManager:
     def __init__(self, filepath=None):
+        def _read_version(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    return json.load(f).get("version", 0)
+            except Exception:
+                return 0
+
         # If no explicit filepath, compute the correct path for the frozen or unfrozen case
         if filepath is None:
             user_path = get_user_albums_path()
-            if os.path.exists(user_path):
-                self.filepath = user_path
+
+            if getattr(sys, 'frozen', False):
+                # We’re in the PyInstaller bundle => use _MEIPASS/app/albums.json
+                base_dir = sys._MEIPASS  # type: ignore[attr-defined]
+                packaged_path = os.path.join(base_dir, "app", "albums.json")
             else:
-                if getattr(sys, 'frozen', False):
-                    # We’re in the PyInstaller bundle => use _MEIPASS/app/albums.json
-                    base_dir = sys._MEIPASS  # type: ignore
-                    self.filepath = os.path.join(base_dir, "app", "albums.json")
+                # Normal dev environment => relative to this file’s directory
+                here = os.path.dirname(__file__)
+                packaged_path = os.path.join(here, "..", "albums.json")
+                packaged_path = os.path.normpath(packaged_path)
+
+            if os.path.exists(user_path):
+                user_ver = _read_version(user_path)
+                pkg_ver = _read_version(packaged_path)
+                if pkg_ver > user_ver:
+                    try:
+                        os.remove(user_path)
+                    except OSError:
+                        pass
+                    self.filepath = packaged_path
                 else:
-                    # Normal dev environment => relative to this file’s directory
-                    # e.g. /path/to/app/core/ => we step up one level => /path/to/app/
-                    here = os.path.dirname(__file__)
-                    self.filepath = os.path.join(here, "..", "albums.json")
-                    self.filepath = os.path.normpath(self.filepath)
+                    self.filepath = user_path
+            else:
+                self.filepath = packaged_path
         else:
             self.filepath = filepath
 
         self.albums = []
+        self.version = 0
         self.load_albums()
 
     def load_albums(self):
         if os.path.exists(self.filepath):
             with open(self.filepath, 'r', encoding='utf-8') as f:
                 data = json.load(f)
+                self.version = data.get("version", 0)
                 self.albums = data.get("albums", [])
         else:
             self.albums = []
+            self.version = 0
 
     def get_albums(self):
         return self.albums
+
+    def get_version(self):
+        return self.version
 
     def reload_albums(self, filepath=None):
         """Reload albums from the provided filepath or existing one."""

--- a/app/ui/album_views/all_albums_view.py
+++ b/app/ui/album_views/all_albums_view.py
@@ -140,7 +140,7 @@ class AllAlbumsView(QWidget):
         self.scroll_area.setWidget(self.container)
 
     def on_update_data_clicked(self):
-        dialog = UpdateDataDialog(self)
+        dialog = UpdateDataDialog(self.albums_manager.get_version(), self)
         if dialog.exec():
             data = dialog.get_data()
             if data:

--- a/app/ui/album_views/update_data_dialog.py
+++ b/app/ui/album_views/update_data_dialog.py
@@ -4,7 +4,7 @@ from PyQt6.QtWidgets import (
 )
 
 class UpdateDataDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, current_version, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Update Album Data")
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint)
@@ -14,6 +14,10 @@ class UpdateDataDialog(QDialog):
         layout = QVBoxLayout()
         layout.setContentsMargins(10, 10, 10, 10)
         layout.setSpacing(10)
+
+        version_label = QLabel(f"Current albums.json version: {current_version}")
+        version_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(version_label)
 
         self.text_edit = QTextEdit()
         self.text_edit.setPlaceholderText("Paste new albums.json contents here")

--- a/app/ui/player/audio_player_dialog.py
+++ b/app/ui/player/audio_player_dialog.py
@@ -1,7 +1,7 @@
 from PyQt6.QtCore import Qt, QUrl, QPoint
 from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QToolTip,
-    QStyle, QStyleOptionSlider, QSlider
+    QStyle, QStyleOptionSlider, QSlider, QSizePolicy
 )
 from PyQt6.QtMultimedia import QMediaPlayer, QAudioOutput
 
@@ -60,6 +60,7 @@ class AudioPlayerDialog(QDialog):
             Qt.WindowType.FramelessWindowHint | Qt.WindowType.Dialog
         )
         self.setModal(False)
+        self.setSizeGripEnabled(True)
 
         self.media_player = QMediaPlayer(self)
         self.audio_output = QAudioOutput()
@@ -67,6 +68,7 @@ class AudioPlayerDialog(QDialog):
         self.media_player.setSource(QUrl.fromLocalFile(audio_path))
 
         self.slider = SeekSlider()
+        self.slider.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.slider.sliderMoved.connect(self.media_player.setPosition)
 
         self.time_label = QLabel("00:00 / 00:00")
@@ -89,6 +91,7 @@ class AudioPlayerDialog(QDialog):
         layout.addWidget(self.time_label)
         layout.addWidget(self.play_button, alignment=Qt.AlignmentFlag.AlignCenter)
         self.setLayout(layout)
+        self.setFixedHeight(self.sizeHint().height())
 
         self.media_player.positionChanged.connect(self.update_position)
         self.media_player.durationChanged.connect(self.update_duration)


### PR DESCRIPTION
## Summary
- show current `albums.json` version in the Update Data dialog
- delete outdated user `albums.json` if packaged version is newer and surface version through AlbumsManager
- allow audio player dialog to be resized horizontally and expand seek bar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892862b7b58832f8d5883e65b1c22e3